### PR TITLE
Image Wrapping

### DIFF
--- a/_assets/stylesheets/layouts/_post.scss
+++ b/_assets/stylesheets/layouts/_post.scss
@@ -1,5 +1,4 @@
 .tpl-post {
-
   article {
     @include make-col-ready();
 
@@ -77,10 +76,10 @@
       }
     }
 
-    .link-title{
+    .link-title {
       color: $red;
       padding: 0;
-      margin-bottom: .5rem;
+      margin-bottom: 0.5rem;
 
       @include media-breakpoint-up(md) {
         text-align: right;
@@ -109,8 +108,8 @@
   }
 
   .post-content {
-
-    h2, .section-header {
+    h2,
+    .section-header {
       font-size: 1.875rem;
       line-height: 1.875rem;
       letter-spacing: $letter-spacing-base;
@@ -131,5 +130,23 @@
     font-size: 1.875rem;
     line-height: 1.875rem;
     letter-spacing: $letter-spacing-base;
+  }
+
+  .block-text-objects img {
+    max-width: 100%;
+  }
+
+  @include media-breakpoint-up(md) {
+    p.clear {
+      clear: both;
+    }
+    p.wrap {
+      float: left;
+      margin: 0 2em 2em 0;
+      &.right {
+        margin: 0 0 2em 2em;
+        float: right;
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR adds new selectors for wrapping images which can be used in Contentful via the following Kramdown syntax... 

```diff
Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus...

<img src="https://.../some-image.jpg" />
+ {: .wrap}

Vestibulum id ligula porta felis euismod semper. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Integer posuere erat a ante venenatis dapibus posuere velit aliquet...
```

Here are the individual selectors that are added via this PR... 

| Selector        | Description |
| :------------- | :----- |
| `.wrap` | Wraps an image with antecedent content (defaults left) | 
| `.wrap.left` | Same as above, just more explicit | 
| `.wrap.right` | Floats image to right instead of left | 
| `.clear` | Clears the float on antecedent paragraphs | 

---

![Screen Shot 2019-03-25 at 2 17 56 PM](https://user-images.githubusercontent.com/50378/54943970-da298e80-4f08-11e9-8ce1-7816ca0d3228.png)
