### PR TITLE
Adjusts hero headline on mobile

### DIFF
--- a/_assets/stylesheets/components/_jumbotron.scss
+++ b/_assets/stylesheets/components/_jumbotron.scss
@@ -8,6 +8,11 @@
     font-size: 4.5rem;
     line-height: 5rem;
 
+    @media (max-width: 768px) {
+      font-size: 3rem; 
+      line-height: 1.25; 
+    }
+
     &.responsive-text {
       font-size: 2.75rem;
 


### PR DESCRIPTION
## Problem 
Hero headline was positioned incorrectly and too large on mobile. 
<img width="405" alt="Screen Shot 2020-07-19 at 5 55 40 PM" src="https://user-images.githubusercontent.com/57996315/87886199-17147100-c9e9-11ea-8e37-76203cdbeeec.png">

## Solution 
Added a media query that resizes and repositions hero headline on mobile. 
<img width="399" alt="Screen Shot 2020-07-19 at 5 56 44 PM" src="https://user-images.githubusercontent.com/57996315/87886217-3c08e400-c9e9-11ea-80fc-5501fe25af4f.png">

